### PR TITLE
Consider SReclaimable memory as free RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ Swap:          512        422         89
 ```
 
 Total memory is 6144 MB and free memory is a value of `total - used + buffers + cached`. In this example, there's
-5219 MB free memory.
+5219 MB free memory. 
+In `/proc/meminfo` file total memory is the value of `MemTotal` field. Free memory calculated as the sum of fields
+`MemFree`, `Buffers`, `Cached` and `SReclaimable`. `SReclaimable` - The part of RAM used by the kernel to cache data 
+structures for its own use, and can be reclaimed, such as caches.
 
 Total amount of memory may change between calls in virtual environments.
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const promisify = require('util').promisify;
 const CpuUsage    = require('./lib/CpuUsage');
 const CpuUsageSma = require('./lib/CpuUsageSma');
 
-const readFileSync  = promisify(fs.readFile);
+const readFileAsync  = promisify(fs.readFile);
 const MB_MULTIPLIER = 1024;
 const MEMINFO_PATH = '/proc/meminfo';
 
@@ -119,7 +119,7 @@ class SystemHealthMonitor {
 
     /* istanbul ignore next */
     async _readMeminfoFile() {
-        return await readFileSync(MEMINFO_PATH, 'utf8');
+        return await readFileAsync(MEMINFO_PATH, 'utf8');
     }
     /**
      * For /proc/meminfo doc see: https://www.centos.org/docs/5/html/5.1/Deployment_Guide/s2-proc-meminfo.html
@@ -127,7 +127,7 @@ class SystemHealthMonitor {
      */
     async _getMemInfo() {
         let memFree           = 0;
-        let indicatorsCounter = 4;
+        let indicatorsCounter = 5;
         let memInfo           = undefined;
 
         try {
@@ -145,7 +145,7 @@ class SystemHealthMonitor {
                 continue;
             }
 
-            if (line.includes('MemFree:') || line.includes('Buffers:') || line.includes('Cached:')) {
+            if (/(^MemFree|^Buffers|^Cached|^SReclaimable):/.test(line)) {
                 memFree += parseInt(getSizeFromMeminfoRow(line));
                 indicatorsCounter--;
                 continue;

--- a/tests/meminfoMock.txt
+++ b/tests/meminfoMock.txt
@@ -3,7 +3,7 @@ MemFree:         1721824 kB
 MemAvailable:    3815636 kB
 Buffers:          419620 kB
 Cached:          2084396 kB
-SwapCached:            0 kB
+SwapCached:          111 kB
 Active:          4676176 kB
 Inactive:        1254936 kB
 Active(anon):    3439312 kB
@@ -24,22 +24,22 @@ SReclaimable:     249324 kB
 SUnreclaim:        39416 kB
 KernelStack:       12096 kB
 PageTables:        51308 kB
-NFS_Unstable:          0 kB
-Bounce:                0 kB
-WritebackTmp:          0 kB
+NFS_Unstable:          9 kB
+Bounce:                9 kB
+WritebackTmp:          9 kB
 CommitLimit:    12312276 kB
 Committed_AS:    9334576 kB
 VmallocTotal:   34359738367 kB
-VmallocUsed:           0 kB
-VmallocChunk:          0 kB
-HardwareCorrupted:     0 kB
+VmallocUsed:           8 kB
+VmallocChunk:          8 kB
+HardwareCorrupted:     8 kB
 AnonHugePages:   1439744 kB
-CmaTotal:              0 kB
-CmaFree:               0 kB
-HugePages_Total:       0
-HugePages_Free:        0
-HugePages_Rsvd:        0
-HugePages_Surp:        0
+CmaTotal:              7 kB
+CmaFree:               7 kB
+HugePages_Total:       7
+HugePages_Free:        7
+HugePages_Rsvd:        7
+HugePages_Surp:        7
 Hugepagesize:       2048 kB
 DirectMap4k:      202560 kB
 DirectMap2M:     8079360 kB


### PR DESCRIPTION
From RedHead [doc](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/s2-proc-meminfo):
> Slab — The total amount of memory, in kibibytes, used by the kernel to cache data structures for its own use.
SReclaimable — The part of Slab that can be reclaimed, such as caches.

That is why "SReclaimable" field must be calculated as free RAM